### PR TITLE
Fix double-free on opaque URIs in URI.str

### DIFF
--- a/main.carp
+++ b/main.carp
@@ -135,9 +135,12 @@ string.
 (URI.str &uri) ; => \"http://admin:password@foo.com\"
 ```
 ")
+  ; N.B. `opaque?` is precomputed as a `Bool` and captured by the scheme lambda
+  ; below; capturing the managed `opaque` field directly and then consuming it
+  ; with `(from … @"")` would free the same string twice.
   (defn str [u]
     (let [s @(scheme u)
-          o @(opaque u)
+          opaque? (just? (opaque u))
           usr @(user u)
           q @(query u)
           h @(host u)
@@ -145,17 +148,17 @@ string.
           pth @(path u)
           f @(fragment u)]
       (concat
-        &[(from
-            (apply s &(fn [s] (concat &[s @":" @(if (just? &o) "" "//")])))
-            @"")
-          (from o @"")
+        &[(from (apply s &(fn [s] (concat &[s @":" @(if opaque? "" "//")]))) @"")
+          (from @(opaque u) @"")
           (from (apply usr &(fn [usr] (concat &[(userinfo u) @"@"]))) @"")
           (from h @"")
           (from
             (apply p
                    &(fn [p] (if (default-port? u) @"" (concat &[@":" (str p)]))))
             @"")
-          @"/"
+          ; opaque URIs (e.g. `mailto:a@b`) have no hierarchical part, so the
+          ; authority/path separator is suppressed for them.
+          @(if opaque? "" "/")
           (from pth @"")
           (from (apply q &(fn [q] (concat &[@"?" q]))) @"")
           (from (apply f &(fn [f] (concat &[@"#" f]))) @"")])))
@@ -516,9 +519,12 @@ This is the inverse of `query-map-from-str`.")
                   (set! res
                         (map res
                              &(fn [res]
+                               ; the opaque part is everything past the colon
                                (set-opaque res
-                                           (Just (from pref
-                                                       (dec (length (source pref)))))))))
+                                           (Just
+                                             (slice (source pref)
+                                                    (inc @(offset pref))
+                                                    (length (source pref))))))))
                   (break))))
           (do (set! res (parse-no-scheme (set-offset @&p 0) res)) (break))))
       res))

--- a/test/uri.carp
+++ b/test/uri.carp
@@ -202,10 +202,42 @@
         &(resolved-str "g#s/../x")
         "resolve g#s/../x (dots in fragment are literal)"))))
 
+(defn test-opaque []
+  (do
+    (IO.println "## Opaque URIs")
+    (with-test test
+      (assert-equal test
+        &(Just @"mailto")
+        (scheme &(unsafe-from-success (URI.parse "mailto:veit@veitheller.de")))
+        "we parse the scheme of an opaque URI")
+      (assert-equal test
+        &(Just @"veit@veitheller.de")
+        (opaque &(unsafe-from-success (URI.parse "mailto:veit@veitheller.de")))
+        "we parse the opaque part as everything after the colon")
+      (assert-equal test
+        &(Just @"g")
+        (opaque &(unsafe-from-success (URI.parse "http:g")))
+        "single-character opaque parts are preserved")
+      ; round-tripping opaque URIs used to double-free in `str` and emit a
+      ; spurious trailing slash; these guard against regressions.
+      (assert-equal test
+        "mailto:veit@veitheller.de"
+        &(str &(unsafe-from-success (URI.parse "mailto:veit@veitheller.de")))
+        "we stringify an opaque URI back to the original")
+      (assert-equal test
+        "urn:isbn:0451450523"
+        &(str &(unsafe-from-success (URI.parse "urn:isbn:0451450523")))
+        "we stringify an opaque URI with colons in the opaque part")
+      (assert-equal test
+        "http:g"
+        &(str &(unsafe-from-success (URI.parse "http:g")))
+        "we stringify an opaque URI without a spurious trailing slash"))))
+
 (defn main []
   (Array.sum
     &[(test-parsing)
       (test-escaping)
       (test-query-string-from-map)
       (test-stringification)
-      (test-resolve)]))
+      (test-resolve)
+      (test-opaque)]))


### PR DESCRIPTION
## Summary

Opaque URIs (`mailto:a@b`, `urn:…`, `http:g`) crashed the library. `URI.str` aborted with a double-free, and even before that the parser was dropping the opaque part. This fixes all three issues and adds coverage.

This came out of reviewing #9: that PR's author skipped the `http:g` resolve test, attributing the crash to a "pre-existing double-free in the runtime" in how `resolve` handles `opaque`. The crash is real and pre-existing, but it's in `URI.str`, not `resolve` or the runtime — any opaque URI parsed on `master` triggers it. This PR is independent of #9.

## The double-free

`URI.str` builds the scheme prefix with a lambda that decided `//` vs `` by capturing the managed `opaque` field by reference (`(just? &o)`). The very next array element consumed that same field with `(from o @"")`, so the one heap string was freed twice → `SIGABRT`. Fix: precompute an `opaque?` `Bool` and capture that (a `Bool` isn't managed).

This is the "lambda captures of linear values cannot be moved out" footgun.

## Two latent bugs the crash was hiding

- **Parser dropped the opaque content.** `parse-scheme` sliced the opaque part with reversed bounds (`(from pref (dec (length (source pref))))`), yielding `""` — so `http:g` parsed to `opaque = (Just "")`. Now slices from the char past the `:` to the end, preserving `g`.
- **Spurious trailing slash.** `str` unconditionally emitted the authority/path separator `/`, so a (correctly-parsed) opaque URI rendered as `mailto:a@b/`. Suppressed for opaque URIs.

## Test plan

- [x] 6 new tests: opaque scheme/opaque-part parsing and round-tripping (`mailto:`, `urn:isbn:…`, `http:g`)
- [x] All existing tests still pass (`carp -x test/uri.carp`, 27 total, 0 failures)
- [x] `carp-fmt --check` clean (verified against carp-fmt HEAD, the version CI uses)
- [x] `angler` clean (verified against angler HEAD)
- [x] `gendocs.carp` runs clean; no public API/doc changes, so generated docs are unchanged